### PR TITLE
Added Legened Value 'Percent' (Shows the percent of total for a series)

### DIFF
--- a/public/app/panels/graph/axisEditor.html
+++ b/public/app/panels/graph/axisEditor.html
@@ -189,6 +189,9 @@
 				<li class="tight-form-item">
 					<editor-checkbox text="Current" model="panel.legend.current" change="legendValuesOptionChanged()"></editor-checkbox>
 				</li>
+				<li class="tight-form-item">
+					<editor-checkbox text="Percent" model="panel.legend.percent" change="legendValuesOptionChanged()"></editor-checkbox>
+				</li>
 				<li class="tight-form-item last">
 					<editor-checkbox text="Total" model="panel.legend.total" change="legendValuesOptionChanged()"></editor-checkbox>
 				</li>

--- a/public/app/panels/graph/legend.js
+++ b/public/app/panels/graph/legend.js
@@ -1,11 +1,12 @@
 define([
   'angular',
+  'app/core/utils/kbn',
   'lodash',
   'jquery',
   'jquery.flot',
-  'jquery.flot.time',
+  'jquery.flot.time'
 ],
-function (angular, _, $) {
+function (angular, kbn, _, $) {
   'use strict';
 
   var module = angular.module('grafana.panels.graph');
@@ -88,6 +89,24 @@ function (angular, _, $) {
           return html + '</th>';
         }
 
+        function getSumTotal(getSeriesStack) {
+          var sumTotal = 0;
+          for (i = 0; i < seriesList.length; i++) {
+            var series = seriesList[i];
+            if (getSeriesStack(series)) {
+              sumTotal += series.stats.total;
+            }
+          }
+
+          return sumTotal;
+        }
+
+        function getSeriesStack(stack, series) {
+          series.applySeriesOverrides(panel.seriesOverrides);
+          var seriesStack = typeof series.stack === 'undefined' || series.stack === true;
+          return stack && seriesStack;
+        }
+
         function render() {
           if (firstRender) {
             elem.append($container);
@@ -111,6 +130,7 @@ function (angular, _, $) {
               header += getTableHeaderHtml('max');
               header += getTableHeaderHtml('avg');
               header += getTableHeaderHtml('current');
+              header += getTableHeaderHtml('percent');
               header += getTableHeaderHtml('total');
             }
             header += '</tr>';
@@ -125,6 +145,12 @@ function (angular, _, $) {
               seriesList = seriesList.reverse();
             }
           }
+
+          var stack = panel.percentage ? null : panel.stack ? true : null;
+
+          var sumTotal = getSumTotal(function (series) {
+            return getSeriesStack(stack, series);
+          });
 
           for (i = 0; i < seriesList.length; i++) {
             var series = seriesList[i];
@@ -156,11 +182,16 @@ function (angular, _, $) {
               var min = series.formatValue(series.stats.min);
               var max = series.formatValue(series.stats.max);
               var total = series.formatValue(series.stats.total);
+              var percent = '-';
+              if (getSeriesStack(stack, series)) {
+                percent = kbn.valueFormats.percent(100 * series.stats.total / sumTotal, 1);
+              }
 
               if (panel.legend.min) { html += '<div class="graph-legend-value min">' + min + '</div>'; }
               if (panel.legend.max) { html += '<div class="graph-legend-value max">' + max + '</div>'; }
               if (panel.legend.avg) { html += '<div class="graph-legend-value avg">' + avg + '</div>'; }
               if (panel.legend.current) { html += '<div class="graph-legend-value current">' + current + '</div>'; }
+              if (panel.legend.percent) { html += '<div class="graph-legend-value percent">' + percent + '</div>'; }
               if (panel.legend.total) { html += '<div class="graph-legend-value total">' + total + '</div>'; }
             }
 

--- a/public/app/panels/graph/module.js
+++ b/public/app/panels/graph/module.js
@@ -85,6 +85,7 @@ function (angular, _, moment, kbn, TimeSeries, PanelMeta) {
         min: false,
         max: false,
         current: false,
+        percent: false,
         total: false,
         avg: false
       },
@@ -281,7 +282,7 @@ function (angular, _, moment, kbn, TimeSeries, PanelMeta) {
 
     $scope.legendValuesOptionChanged = function() {
       var legend = $scope.panel.legend;
-      legend.values = legend.min || legend.max || legend.avg || legend.current || legend.total;
+      legend.values = legend.min || legend.max || legend.avg || legend.current || legend.percent || legend.total;
       $scope.render();
     };
 

--- a/public/less/panel_graph.less
+++ b/public/less/panel_graph.less
@@ -40,6 +40,9 @@
   &.avg:before {
     content: "Avg: "
   }
+  &.percent:before {
+    content: "Percent: "
+  }
 }
 
 .graph-legend-icon .fa {
@@ -105,7 +108,7 @@
   }
 
   .graph-legend-value {
-    &.current, &.max, &.min, &.total, &.avg {
+    &.current, &.max, &.min, &.total, &.avg, &.percent {
       &:before {
         content: '';
       }
@@ -271,5 +274,3 @@
   text-align: center;
   font-size: 12px;
 }
-
-


### PR DESCRIPTION
Allows to see the percent of the total value for stacked series in the legend.

I branched it from your branch ("add_percent_on_stacked_series_tooltip") on purpose because I think it should be merged to your PR (grafana/grafana#3362) :+1: 

![screenshot from 2015-12-04 11 59 58](https://cloud.githubusercontent.com/assets/746471/11586866/959584dc-9a7e-11e5-9e55-ef32c644f59b.png)
